### PR TITLE
Format tag comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 A GitHub Action to create and read git tags.
 This is a composite action that combines other actions, like:
+
 - anothrNick/github-tag-action
 - peter-evans/find-comment
 - peter-evans/create-or-update-comment
 - actions/github-script
 - chuhlomin/render-template
-The simplest use-case for this action is to create a git tag from a push event.
-In that case all it does is create and push the tag.
-Another use-case is to create a tag from a pull request using a label event.
-In that case the action creates and pushes the git tag, but also adds a comment to the pull request with information about the tag.
-This action is also able to read comments created in PRs and retrieve the tag name.
+  The simplest use-case for this action is to create a git tag from a push event.
+  In that case all it does is create and push the tag.
+  Another use-case is to create a tag from a pull request using a label event.
+  In that case the action creates and pushes the git tag, but also adds a comment to the pull request with information
+  about the tag.
+  This action is also able to read comments created in PRs and retrieve the tag name.
 
 ## Inputs
 
@@ -26,7 +28,6 @@ This action is also able to read comments created in PRs and retrieve the tag na
 | workflow-run-url         | The url of the workflow run.                                                                       | false    | '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' |
 | github-token             | The GitHub token used for creating the tag.                                                        | true     |                                                                                       |
 
-
 ## Outputs
 
 | Output | Description            | 
@@ -35,7 +36,14 @@ This action is also able to read comments created in PRs and retrieve the tag na
 
 ## Usage
 
-To create pull request comments, the action needs a template under `.github/templates/tag-comment.md`, with the following variables.
+The default `secrets.GITHUB_TOKEN` is able to create and push the tags to GitHub. However, things like tags (or
+branches, etc) created using that token do not trigger subsequent workflows. That means that, when using the default
+github actions token, workflows that are triggered won't execute. For that to happen, a personal access token needs to
+be used.
+
+To create pull request comments, the action needs a template under `.github/templates/tag-comment.md`, with the
+following variables.
+
 ```md
 {{ .header }}
 
@@ -43,12 +51,14 @@ To create pull request comments, the action needs a template under `.github/temp
 
 {{ .footer }}
 ```
+
 The template can contain any other static text.
 
 ### Create a tag on a push event
 
-The following workflow configuration creates tags on push events to `main` branch. 
+The following workflow configuration creates tags on push events to `main` branch.
 The tags are created sequentially and prefixed with `v`.
+
 ```yaml
 name: Git Tag - Push
 
@@ -71,11 +81,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-###  Create a tag from a pull request
+### Create a tag from a pull request
 
 The following workflow configuration creates a tag when a pull request is labeled with `tag`.
-The tags are created sequentially taking into account both the latest tag in the repository and the latest tag created in the pull request.
+The tags are created sequentially taking into account both the latest tag in the repository and the latest tag created
+in the pull request.
 The tags are prefixed with `v` and suffixed with `pr<PR-NUMBER>-rc.<TAG-NUMBER>`.
+
 ```yaml
 name: Git Tag - Pull Request
 
@@ -89,7 +101,7 @@ jobs:
   tag:
     name: Create git tag with comment on PR
     runs-on: ubuntu-latest
-    if:  github.event.label.name == 'tag'
+    if: github.event.label.name == 'tag'
     steps:
       - name: Git tag
         uses: GRESB/action-git-tag@main
@@ -99,13 +111,16 @@ jobs:
           release-candidate-suffix: rc
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
 After the tag is created a comment is added to the pull request, naming the tag.
 When the same pull request is re-labeled with `tag` the comment is updated.
 
 ### Read a tag from a pull request comment
 
-The following workflow configuration reads a previously created tag from a pull request comment, when the pull request is labeled with `read-tag`.
+The following workflow configuration reads a previously created tag from a pull request comment, when the pull request
+is labeled with `read-tag`.
 The tag name is then made available as an output.
+
 ```yaml
 name: Git Tag - Pull Request
 

--- a/action.yaml
+++ b/action.yaml
@@ -84,6 +84,7 @@ runs:
         echo "tag_comment_body<<EOT" >> "${GITHUB_OUTPUT}"
         echo "Tag: \`${release}\`" >> "${GITHUB_OUTPUT}"
         echo "" >> "${GITHUB_OUTPUT}"
+        echo "" >> "${GITHUB_OUTPUT}"
         echo "${comment_body}" >> "${GITHUB_OUTPUT}"
         echo "EOT" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
This PR improves the format of the tag comment by adding an extra empty line between the line that mentions the tag and the body that is received from inputs. It also documents the need for a PAT in order to trigger workflows on the created tags.