### PR TITLE
Set action outputs also when creating tags

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,11 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create git tag
+        id: tag
         uses: ./
         with:
           create: true
           pr-number: ${{ github.event.pull_request.number }}
           github-token: ${{ secrets.BOT_PAT }}
+      - name: Echo created tag
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Created tag for PR push
+            Tag: ${{ steps.tag.outputs.tag }}
+            SHA: ${{ steps.tag.outputs.sha }}
+            Is Final: ${{ steps.tag.outputs.is-final }}
       - name: Read git tag
         id: read
         uses: ./
@@ -31,6 +41,7 @@ jobs:
         with:
           issue-number: ${{ steps.read.outputs.pr-number }}
           body: |
+            ## Read tag for PR push
             Tag: ${{ steps.read.outputs.tag }}
             SHA: ${{ steps.read.outputs.sha }}
             Is Final: ${{ steps.read.outputs.is-final }}

--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -19,12 +19,12 @@ jobs:
         with:
           read: true
           ref: ${{ github.ref }}
-
       - name: Echo read tag
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ steps.read.outputs.pr-number }}
           body: |
+            ## Read tag details on tag push
             Tag: ${{ steps.read.outputs.tag }}
             SHA: ${{ steps.read.outputs.sha }}
             Is Final: ${{ steps.read.outputs.is-final }}

--- a/action.yaml
+++ b/action.yaml
@@ -114,17 +114,18 @@ runs:
         fi
 
         # Determine the commit sha of the commit that originated the tag
-        if [[ "${is_final}" == "true" ]]; then
-          # Final release tagged on main
-          sha="${{ github.event.after }}"
-        else
-          # Release candidate tagged on PR
-          echo "DEBUG :: github event ${{ toJSON(github.event) }}"
-          message='${{ github.event.commits[0].message }}'
-          echo "DEBUG :: reading commit message to discover SHA"
-          echo "DEBUG :: commit message = ${message}"
-          sha="$( sed -e "s/Merge //" -e "s/ into .*//" <<<"${message}" )"
-        fi
+        sha="${{ github.event.after }}"
+        # TODO: remove this commented out block if ${{ github.event.after }} works to determine the sha for all events
+        #        if [[ "${is_final}" == "true" ]]; then
+        #          # Final release tagged on main
+        #          sha="${{ github.event.after }}"
+        #        else
+        #          # Release candidate tagged on PR
+        #          echo "DEBUG :: github event ${github_event}"
+        #          echo "DEBUG :: reading commit message to discover SHA"
+        #          echo "DEBUG :: commit message = ${commit_message}"
+        #          sha="$( sed -e "s/Merge //" -e "s/ into .*//" <<<"${commit_message}" )"
+        #        fi
 
         pr_number=$( sed -E -e "s/v[0-9]+\.[0-9]+.[0-9]+//" -e "s/-pr//" -e "s/-${rc_suffix}.[0-9]+//" <<<"${tag}" )
 
@@ -140,6 +141,8 @@ runs:
         echo "::debug::pr-number=${pr_number}"
       env:
         rc_suffix: ${{ inputs.release-candidate-suffix }}
+        #        github_event: ${{ toJSON(github.event) }}
+        #        commit_message: ${{ github.event.commits[0].message }}
     - name: Prepare tag PR comment content
       id: tag-comment
       if: inputs.create && inputs.pr-number

--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,12 @@ runs:
         WITH_V: true
         PRERELEASE_SUFFIX: pr${{ inputs.pr-number }}-${{ inputs.release-candidate-suffix }}
         PRERELEASE: ${{ inputs.pr-number != 0 }}
+    - name: Export new tag to environment
+      if: inputs.create
+      shell: bash
+      run: echo "tag=${tag}" >> "${GITHUB_ENV}"
+      env:
+        tag: ${{ steps.tag.outputs.new_tag }}
     - name: Find Tag Comment
       uses: peter-evans/find-comment@v2
       if: (inputs.read || inputs.create) && inputs.pr-number
@@ -97,7 +103,6 @@ runs:
       env:
         tag_ref: ${{ inputs.ref }}
     - name: Extract tag information
-      if: inputs.read
       id: read-pr-tag
       shell: bash
       run: |
@@ -114,7 +119,10 @@ runs:
           sha="${{ github.event.after }}"
         else
           # Release candidate tagged on PR
+          echo "DEBUG :: github event ${{ toJSON(github.event) }}"
           message='${{ github.event.commits[0].message }}'
+          echo "DEBUG :: reading commit message to discover SHA"
+          echo "DEBUG :: commit message = ${message}"
           sha="$( sed -e "s/Merge //" -e "s/ into .*//" <<<"${message}" )"
         fi
 


### PR DESCRIPTION
This PR sets the action outputs also when creating tags. Previously these outputs would only be available when reading tags.