### PR TITLE
Fix tag sha detection

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -114,18 +114,14 @@ runs:
         fi
 
         # Determine the commit sha of the commit that originated the tag
-        sha="${{ github.event.after }}"
-        # TODO: remove this commented out block if ${{ github.event.after }} works to determine the sha for all events
-        #        if [[ "${is_final}" == "true" ]]; then
-        #          # Final release tagged on main
-        #          sha="${{ github.event.after }}"
-        #        else
-        #          # Release candidate tagged on PR
-        #          echo "DEBUG :: github event ${github_event}"
-        #          echo "DEBUG :: reading commit message to discover SHA"
-        #          echo "DEBUG :: commit message = ${commit_message}"
-        #          sha="$( sed -e "s/Merge //" -e "s/ into .*//" <<<"${commit_message}" )"
-        #        fi
+        if [[ "${commit_message}" =~ Merge\ .*\ into\ .* ]]; then
+          echo "DEBUG :: reading commit message to discover SHA"
+          echo "DEBUG :: commit message = ${commit_message}"
+          sha="$( sed -e "s/Merge //" -e "s/ into .*//" <<<"${commit_message}" )"
+        else 
+          echo "DEBUG :: reading SHA from github event after field"
+          sha="${event_after}"
+        fi
 
         pr_number=$( sed -E -e "s/v[0-9]+\.[0-9]+.[0-9]+//" -e "s/-pr//" -e "s/-${rc_suffix}.[0-9]+//" <<<"${tag}" )
 
@@ -141,8 +137,8 @@ runs:
         echo "::debug::pr-number=${pr_number}"
       env:
         rc_suffix: ${{ inputs.release-candidate-suffix }}
-        #        github_event: ${{ toJSON(github.event) }}
-        #        commit_message: ${{ github.event.commits[0].message }}
+        commit_message: ${{ github.event.commits[0].message }}
+        event_after: ${{ github.event.after }}
     - name: Prepare tag PR comment content
       id: tag-comment
       if: inputs.create && inputs.pr-number


### PR DESCRIPTION
This PR fixes the way commit SHAs for tags are read. Sometimes it needs to be read from the commit message that GitHub generates internally for the PRs, other times directly from the GitHub event.