### PR TITLE
Print github event

### DIFF
--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -20,6 +20,7 @@ jobs:
           read: true
           ref: ${{ github.ref }}
       - name: Echo read tag
+        if: steps.read.outputs.pr-number
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ steps.read.outputs.pr-number }}

--- a/action.yaml
+++ b/action.yaml
@@ -52,6 +52,13 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Debug github event
+      shell: bash
+      run: |
+        echo "DEBUG :: github event needs to be used to make it available to the action"
+        echo "DEBUG :: \n${github_event}"
+      env:
+        github_event: ${{ toJSON(github.event) }}
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.52.0
       if: inputs.create


### PR DESCRIPTION
This PR prints the GitHub event JSON because it seems that without printing it the attributes of the event won't be available in the action steps.