### PR TITLE
Fix tag sha detection

### DIFF
--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -20,6 +20,7 @@ jobs:
           read: true
           ref: ${{ github.ref }}
       - name: Echo read tag
+        if: steps.read.outputs.pr-number
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ steps.read.outputs.pr-number }}

--- a/action.yaml
+++ b/action.yaml
@@ -118,9 +118,12 @@ runs:
           echo "DEBUG :: reading commit message to discover SHA"
           echo "DEBUG :: commit message = ${commit_message}"
           sha="$( sed -e "s/Merge //" -e "s/ into .*//" <<<"${commit_message}" )"
-        else 
+        elif [[ "${event_after}" != "" ]]; then
           echo "DEBUG :: reading SHA from github event after field"
           sha="${event_after}"
+        else
+          echo "DEBUG :: reading SHA from github event pull_request head sha"
+          sha="${pr_head_sha}"
         fi
 
         pr_number=$( sed -E -e "s/v[0-9]+\.[0-9]+.[0-9]+//" -e "s/-pr//" -e "s/-${rc_suffix}.[0-9]+//" <<<"${tag}" )
@@ -139,6 +142,7 @@ runs:
         rc_suffix: ${{ inputs.release-candidate-suffix }}
         commit_message: ${{ github.event.commits[0].message }}
         event_after: ${{ github.event.after }}
+        pr_head_sha: ${{ github.event.pull_request.head.sha }}
     - name: Prepare tag PR comment content
       id: tag-comment
       if: inputs.create && inputs.pr-number


### PR DESCRIPTION
This PR falls-back to the github event pull_request head to determine the commit SHA of a tag.