### PR TITLE
Upgrade github-tag-action to 1.61.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,7 +53,7 @@ runs:
   using: "composite"
   steps:
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.52.0
+      uses: anothrNick/github-tag-action@1.61.0
       if: inputs.create
       id: tag
       env:


### PR DESCRIPTION
This PR upgrades the github-tag-action (action that creates the git tags) to a newer version (1.61.0) which should have switched from the old output syntax to the new.